### PR TITLE
Use single upload for file less than 20 m

### DIFF
--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -95,14 +95,15 @@ def upload_file(bucket, source, destination, s3_ssenc, bufsize):
                 k = Key(bucket)
                 k.key = destination
                 k.set_contents_from_filename(source, cb=percent_cb, num_cb=10)
-            except Exception:
-                logger.warn("Error uploading file {!s} to {!s}.\
-                    Retry count: {}".format(source, destination, retry_count))
+            except Exception as e:
+                #logger.warn("Error uploading file {!s} to {!s}.\
+                #    Retry count: {}".format(source, destination, retry_count))
                 print("Error uploading file {!s} to {!s}.\
-                    Retry count: {}".format(source, destination, retry_count))
+                        Retry count: {} Error:{}".format(source, destination, retry_count, e))
                 retry_count = retry_count + 1
                 if retry_count >= MAX_RETRY_COUNT:
-                    logger.exception("Retried too many times uploading file")
+                    #logger.exception("Retried too many times uploading file")
+                    print("Retried too many times uploading file")
                     raise
             completed = True
     else:

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -87,19 +87,19 @@ def destination_path(s3_base_path, file_path, compressed=True):
 def upload_file(bucket, source, destination, s3_ssenc, bufsize):
     completed = False
     retry_count = 0
-    # If file size less than MULTI_PART_UPLOAD_THRESHOLD, use single part
-    # upload
+    # If file size less than MULTI_PART_UPLOAD_THRESHOLD,
+    # use single part upload
     if os.path.getsize(source) <= int(MULTI_PART_UPLOAD_THRESHOLD * MBFACTOR):
         while not completed and retry_count < MAX_RETRY_COUNT:
             try:
-                k = Key(bucket)
-                k.key = destination
-                k.set_contents_from_filename(source)
+                k = Key(bucket)  # Initialize S3 bucket object
+                k.key = destination  # Prepend S3 path prior to uploading
+                k.set_contents_from_filename(source, encrypt_key=s3_ssenc)
             except Exception:
                 logger.warn("Error uploading file {!s} to {!s}.\
                     Retry count: {}".format(source, destination, retry_count))
                 print("Error uploading file {!s} to {!s}.\
-                        Retry count: {}".format(source, destination, retry_count))
+                    Retry count: {}".format(source, destination, retry_count))
                 retry_count = retry_count + 1
                 if retry_count >= MAX_RETRY_COUNT:
                     logger.exception("Retried too many times uploading file")

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -14,7 +14,6 @@ try:
 except ImportError:
     from yaml import Loader
 import os
-import sys
 import time
 import glob
 import logging
@@ -83,9 +82,6 @@ def destination_path(s3_base_path, file_path, compressed=True):
     suffix = compressed and '.lzo' or ''
     return '/'.join([s3_base_path, file_path + suffix])
 
-def percent_cb(complete, total):
-    sys.stdout.write('.')
-    sys.stdout.flush()
 
 @map_wrap
 def upload_file(bucket, source, destination, s3_ssenc, bufsize):
@@ -98,15 +94,15 @@ def upload_file(bucket, source, destination, s3_ssenc, bufsize):
             try:
                 k = Key(bucket)
                 k.key = destination
-                k.set_contents_from_filename(source, cb=percent_cb, num_cb=10)
-            except Exception as e:
-                #logger.warn("Error uploading file {!s} to {!s}.\
-                #    Retry count: {}".format(source, destination, retry_count))
+                k.set_contents_from_filename(source)
+            except Exception:
+                logger.warn("Error uploading file {!s} to {!s}.\
+                    Retry count: {}".format(source, destination, retry_count))
                 print("Error uploading file {!s} to {!s}.\
-                        Retry count: {} Error:{}".format(source, destination, retry_count, e))
+                        Retry count: {}".format(source, destination, retry_count))
                 retry_count = retry_count + 1
                 if retry_count >= MAX_RETRY_COUNT:
-                    #logger.exception("Retried too many times uploading file")
+                    logger.exception("Retried too many times uploading file")
                     print("Retried too many times uploading file")
                     raise
             completed = True

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -87,7 +87,8 @@ def destination_path(s3_base_path, file_path, compressed=True):
 def upload_file(bucket, source, destination, s3_ssenc, bufsize):
     completed = False
     retry_count = 0
-    print("srouce file size={0}".format(os.path.getsize(source)))
+    # If file size less than MULTI_PART_UPLOAD_THRESHOLD, use single part
+    # upload
     if os.path.getsize(source) <= int(MULTI_PART_UPLOAD_THRESHOLD * MBFACTOR):
         print("[Single file upload]:{0}".format(source))
         try:
@@ -96,25 +97,24 @@ def upload_file(bucket, source, destination, s3_ssenc, bufsize):
             print("upload to {}".format(k.key))
         except Exception:
             print("Error uploading file {0}".format(source))
-        # Use single upload
-    print("File:{0}".format(source))
-    while not completed and retry_count < MAX_RETRY_COUNT:
-        mp = bucket.initiate_multipart_upload(destination, encrypt_key=s3_ssenc)
-        try:
-            for i, chunk in enumerate(compressed_pipe(source, bufsize)):
-                mp.upload_part_from_file(chunk, i+1)
-        except Exception:
-            logger.warn("Error uploading file {!s} to {!s}.\
-                Retry count: {}".format(source, destination, retry_count))
-            print("Error uploading file {!s} to {!s}.\
-                Retry count: {}".format(source, destination, retry_count))
-            cancel_upload(bucket, mp, destination)
-            retry_count = retry_count + 1
-            if retry_count >= MAX_RETRY_COUNT:
-                logger.exception("Retried too many times uploading file")
-                raise
-        mp.complete_upload()
-        completed = True
+    else:
+        while not completed and retry_count < MAX_RETRY_COUNT:
+            mp = bucket.initiate_multipart_upload(destination, encrypt_key=s3_ssenc)
+            try:
+                for i, chunk in enumerate(compressed_pipe(source, bufsize)):
+                    mp.upload_part_from_file(chunk, i+1)
+            except Exception:
+                logger.warn("Error uploading file {!s} to {!s}.\
+                    Retry count: {}".format(source, destination, retry_count))
+                print("Error uploading file {!s} to {!s}.\
+                    Retry count: {}".format(source, destination, retry_count))
+                cancel_upload(bucket, mp, destination)
+                retry_count = retry_count + 1
+                if retry_count >= MAX_RETRY_COUNT:
+                    logger.exception("Retried too many times uploading file")
+                    raise
+            mp.complete_upload()
+            completed = True
 
 
 @timeout(UPLOAD_TIMEOUT)

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -94,6 +94,7 @@ def upload_file(bucket, source, destination, s3_ssenc, bufsize):
             try:
                 k = Key(bucket)
                 k.key = destination
+                k.set_contents_from_filename(source, cb=percent_cb, num_cb=10)
             except Exception:
                 logger.warn("Error uploading file {!s} to {!s}.\
                     Retry count: {}".format(source, destination, retry_count))

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -14,6 +14,7 @@ try:
 except ImportError:
     from yaml import Loader
 import os
+import sys
 import time
 import glob
 import logging
@@ -82,6 +83,9 @@ def destination_path(s3_base_path, file_path, compressed=True):
     suffix = compressed and '.lzo' or ''
     return '/'.join([s3_base_path, file_path + suffix])
 
+def percent_cb(complete, total):
+    sys.stdout.write('.')
+    sys.stdout.flush()
 
 @map_wrap
 def upload_file(bucket, source, destination, s3_ssenc, bufsize):

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -87,14 +87,17 @@ def destination_path(s3_base_path, file_path, compressed=True):
 def upload_file(bucket, source, destination, s3_ssenc, bufsize):
     completed = False
     retry_count = 0
+    print("srouce file size={0}".format(os.path.getsize(source)))
     if os.path.getsize(source) <= int(MULTI_PART_UPLOAD_THRESHOLD * MBFACTOR):
-        print("[Single file upload]:source")
+        print("[Single file upload]:{0}".format(source))
         try:
             k = Key(bucket)
             k.key = destination
             print("upload to {}".format(k.key))
+        except Exception:
+            print("Error uploading file {0}".format(source))
         # Use single upload
-    #print("File:{0}".format(source))
+    print("File:{0}".format(source))
     while not completed and retry_count < MAX_RETRY_COUNT:
         mp = bucket.initiate_multipart_upload(destination, encrypt_key=s3_ssenc)
         try:


### PR DESCRIPTION
For file size less than 20M, use single upload instead of multi-upload