### PR TITLE
Add multi table support

### DIFF
--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -234,10 +234,8 @@ def create_upload_manifest(
             path += ['*']
 
             path = os.path.join(*path)
-            #glob_results = '\n'.join(glob.glob(os.path.join(path)))
             if len(exclude_tables_list) > 0:
                 for f in glob.glob(os.path.join(path)):
-                #for f in glob_results.split("\n"):
                 # Get the table name
                 # The current format of a file path looks like:
                 # /var/lib/cassandra/data03/system/compaction_history/snapshots/20151102182658/system-compaction_history-jb-6684-Summary.db

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -236,9 +236,9 @@ def create_upload_manifest(
             path = os.path.join(*path)
             if len(exclude_tables_list) > 0:
                 for f in glob.glob(os.path.join(path)):
-                # Get the table name
-                # The current format of a file path looks like:
-                # /var/lib/cassandra/data03/system/compaction_history/snapshots/20151102182658/system-compaction_history-jb-6684-Summary.db
+                    # Get the table name
+                    # The current format of a file path looks like:
+                    # /var/lib/cassandra/data03/system/compaction_history/snapshots/20151102182658/system-compaction_history-jb-6684-Summary.db
                     if f.split('/')[-4] not in exclude_tables_list:
                         files.append(f.strip())
             else:

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -234,13 +234,17 @@ def create_upload_manifest(
             path += ['*']
 
             path = os.path.join(*path)
-            glob_results = '\n'.join(glob.glob(os.path.join(path)))
-            for f in glob_results.split("\n"):
+            #glob_results = '\n'.join(glob.glob(os.path.join(path)))
+            if len(exclude_tables_list) > 0:
+                for f in glob.glob(os.path.join(path)):
+                #for f in glob_results.split("\n"):
                 # Get the table name
                 # The current format of a file path looks like:
                 # /var/lib/cassandra/data03/system/compaction_history/snapshots/20151102182658/system-compaction_history-jb-6684-Summary.db
-                if f.split('/')[-4] not in exclude_tables_list:
-                    files.append(f.strip())
+                    if f.split('/')[-4] not in exclude_tables_list:
+                        files.append(f.strip())
+            else:
+                files.append(f.strip() for f in glob.glob(os.path.join(path)))
 
     with open(manifest_path, 'w') as manifest:
         for f in files:

--- a/cassandra_snapshotter/agent.py
+++ b/cassandra_snapshotter/agent.py
@@ -70,6 +70,9 @@ def compressed_pipe(path, size):
 def compress_file(path):
     """
     Return an lzoped file
+
+    Note: This function is not being used at the moment, but will be
+    used against single file upload
     """
     subprocess.call([LZOP_BIN, path])
     path = path + '.lzo'
@@ -124,7 +127,9 @@ def upload_file(bucket, source, destination, s3_ssenc, bufsize):
     else:  # Big file, use multi part upload
         print("[MU] {0}".format(source))
         while not completed and retry_count < MAX_RETRY_COUNT:
-            mp = bucket.initiate_multipart_upload(destination, encrypt_key=s3_ssenc)
+            mp = bucket.initiate_multipart_upload(
+                destination,
+                encrypt_key=s3_ssenc)
             try:
                 for i, chunk in enumerate(compressed_pipe(source, bufsize)):
                     mp.upload_part_from_file(chunk, i+1)
@@ -200,7 +205,7 @@ def get_data_path(conf_path):
 
 def create_upload_manifest(
         snapshot_name, snapshot_keyspaces, snapshot_table,
-        conf_path, manifest_path, incremental_backups=False):
+        conf_path, manifest_path, exclude_tables, incremental_backups=False):
     if snapshot_keyspaces:
         keyspace_globs = snapshot_keyspaces.split()
     else:
@@ -213,9 +218,10 @@ def create_upload_manifest(
 
     data_paths = get_data_path(conf_path)
     files = []
+    exclude_tables_list = exclude_tables.split(',')
     for data_path in data_paths:
         for keyspace_glob in keyspace_globs:
-            logger.info("Creating data path: {0}/{1}".format(data_path,keyspace_glob))
+            logger.info("Creating data path: {0}/{1}".format(data_path, keyspace_glob))
             path = [
                 data_path,
                 keyspace_glob,
@@ -229,10 +235,16 @@ def create_upload_manifest(
 
             path = os.path.join(*path)
             glob_results = '\n'.join(glob.glob(os.path.join(path)))
-            files.extend([f.strip() for f in glob_results.split("\n")])
+            for f in glob_results.split("\n"):
+                # Get the table name
+                # The current format of a file path looks like:
+                # /var/lib/cassandra/data03/system/compaction_history/snapshots/20151102182658/system-compaction_history-jb-6684-Summary.db
+                if f.split('/')[-4] not in exclude_tables_list:
+                    files.append(f.strip())
 
     with open(manifest_path, 'w') as manifest:
-        manifest.write('\n'.join("%s" % f for f in files))
+        for f in files:
+            manifest.write(f + '\n')
 
 
 def main():
@@ -275,6 +287,8 @@ def main():
         '--snapshot_keyspaces', default='', required=False, type=str)
     manifest_parser.add_argument(
         '--snapshot_table', required=False, default='', type=str)
+    manifest_parser.add_argument(
+        '--exclude_tables', required=False, type=str)
 
     args = base_parser.parse_args()
     subcommand = args.subcommand
@@ -286,6 +300,7 @@ def main():
             args.snapshot_table,
             args.conf_path,
             args.manifest_path,
+            args.exclude_tables,
             args.incremental_backups
         )
 

--- a/cassandra_snapshotter/main.py
+++ b/cassandra_snapshotter/main.py
@@ -53,7 +53,8 @@ def run_backup(args):
         backup_schema=args.backup_schema,
         buffer_size=args.buffer_size,
         use_sudo=args.use_sudo,
-        connection_pool_size=args.connection_pool_size
+        connection_pool_size=args.connection_pool_size,
+        exclude_tables=args.exclude_tables
     )
 
     if create_snapshot:
@@ -131,6 +132,11 @@ def main():
     backup_parser = subparsers.add_parser('backup', help="Create a snapshot")
 
     # snapshot / backup arguments
+    backup_parser.add_argument(
+        '--exclude-tables',
+        default='',
+        help="Column families you want to skip")
+
     backup_parser.add_argument(
         '--buffer-size',
         default=64,

--- a/cassandra_snapshotter/snapshotting.py
+++ b/cassandra_snapshotter/snapshotting.py
@@ -264,8 +264,7 @@ class BackupWorker(object):
         prefix = '/'.join(snapshot.base_path.split(
             '/') + [self.get_current_node_hostname()])
 
-        #manifest_path = '{}/backupmanifest'.format(expanduser('~'))
-        manifest_path = '{}/backupmanifest'.format('/home/txu')
+        manifest_path = '{}/backupmanifest'.format(expanduser('~'))
         manifest_command = "cassandra-snapshotter-agent \
             %(incremental_backups)s create-upload-manifest \
             --manifest_path=%(manifest_path)s \

--- a/cassandra_snapshotter/snapshotting.py
+++ b/cassandra_snapshotter/snapshotting.py
@@ -238,7 +238,7 @@ class BackupWorker(object):
                  aws_access_key_id, s3_bucket_region, s3_ssenc,
                  s3_connection_host, cassandra_conf_path, use_sudo,
                  nodetool_path, cassandra_bin_dir, backup_schema,
-                 buffer_size, connection_pool_size=12):
+                 buffer_size, exclude_tables, connection_pool_size=12):
         self.aws_secret_access_key = aws_secret_access_key
         self.aws_access_key_id = aws_access_key_id
         self.s3_bucket_region = s3_bucket_region
@@ -255,6 +255,7 @@ class BackupWorker(object):
             self.use_sudo = bool(strtobool(use_sudo))
         else:
             self.use_sudo = use_sudo
+        self.exclude_tables = exclude_tables
 
     def get_current_node_hostname(self):
         return env.host_string
@@ -263,21 +264,24 @@ class BackupWorker(object):
         prefix = '/'.join(snapshot.base_path.split(
             '/') + [self.get_current_node_hostname()])
 
-        manifest_path = '{}/backupmanifest'.format(expanduser('~'))
+        #manifest_path = '{}/backupmanifest'.format(expanduser('~'))
+        manifest_path = '{}/backupmanifest'.format('/home/txu')
         manifest_command = "cassandra-snapshotter-agent \
             %(incremental_backups)s create-upload-manifest \
             --manifest_path=%(manifest_path)s \
             --snapshot_name=%(snapshot_name)s \
             --snapshot_keyspaces=%(snapshot_keyspaces)s \
             --snapshot_table=%(snapshot_table)s \
-            --conf_path=%(conf_path)s"
+            --conf_path=%(conf_path)s \
+            --exclude_tables=%(exclude_tables)s"
         cmd = manifest_command % dict(
             manifest_path=manifest_path,
             snapshot_name=snapshot.name,
             snapshot_keyspaces=snapshot.keyspaces,
             snapshot_table=snapshot.table,
             conf_path=self.cassandra_conf_path,
-            incremental_backups=incremental_backups and\
+            exclude_tables=self.exclude_tables,
+            incremental_backups=incremental_backups and \
                 '--incremental_backups' or ''
         )
         if self.use_sudo:


### PR DESCRIPTION
Cassandra nodetool only supports the following snapshot scenario:
1. Snapshot all keyspaces
2. Snapshot one or more keyspaces and all cfs
3. Snapshot a single cf

This PR will allow snapshot a single keyspace and multiple tables of that single keyspace